### PR TITLE
Fixed sub-module install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(name='plycutter',
       version='0.0',
@@ -8,7 +8,7 @@ setup(name='plycutter',
       author_email='tuomas@hipcode.fi',
       license='AGPL-3.0 or later',
       python_requires='>=3.7.0',
-      packages=['plycutter'],
+      packages=find_packages(),
       zip_safe=True,
       install_requires=[
           'numpy',


### PR DESCRIPTION
Sub modules weren't installing properly.

I use pipx to manage virtualenvs for all these little python apps, this change fixes the install so that it properly installs the `plycutter.geometry` module and you can use a simple `pipx install git+https://github.com/tjltjl/plycutter.git` to install the app.